### PR TITLE
Deploy Action を修正

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "16"
-      - run: yarn install
+          cache: yarn
+      # node_modules ではなく yarn cache をキャッシュする
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: touch ./docs/.nojekyll
       - uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,12 +11,12 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: macos-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
       - run: yarn install
       - run: yarn build
       - run: touch ./docs/.nojekyll


### PR DESCRIPTION
変更点と根拠

1. `run-on` を `ubuntu-20.04` に変更
    macos-latest でも困らないと思いますが ci.yaml と揃えた方が良いと思ったので
2. actions/checkout と actions/setup-node を v3 に変更
3. キャッシュを有効化
    node_modules をキャッシュすると yarn.lock の変更毎に install が走り遅くなるので yarn cache をキャッシュする方針にしました